### PR TITLE
Fixing a bug where DualPath couldn't be used with DataParallel.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,14 @@
 Changelog
 =========
 
+v1.1.2
+------
+- Fixed a bug in Dual Path models where they couldn't be used with DataParallel.
+
 v1.1.1
 ------
 - Allowed MixSourceFolder to mix sources on the fly.
+- Adding OnTheFly dataset for mixing sources on the fly using a function.
 - Added effects utilities for data augmentation.
 - Fixed bug with ignite 0.4.0
 

--- a/nussl/__init__.py
+++ b/nussl/__init__.py
@@ -5,7 +5,7 @@ except Exception:
     vamp_imported = False
 
 # Current nussl version
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 class ImportErrorClass(object):
     def __init__(self, lib, **kwargs):

--- a/nussl/ml/networks/modules/blocks.py
+++ b/nussl/ml/networks/modules/blocks.py
@@ -790,12 +790,10 @@ class DualPath(nn.Module):
         self.chunk_size = chunk_size
         self.hop_size = hop_size
         
-        blocks = []
+        self.layers = nn.ModuleList()
         for i in range(num_layers):
             _block = DualPathBlock(n_features=bottleneck_size, **kwargs)
-            blocks.append(_block)
-            self.add_module(f'layer{i}', _block)
-        self.layers = blocks
+            self.layers.append(_block)
         self.skip_connection = skip_connection
         self.prelu = nn.PReLU()
         self.bottleneck = nn.Linear(in_features, bottleneck_size)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('extra_requirements.txt') as f:
 
 setup(
     name='nussl',
-    version='1.1.1',
+    version='1.1.2',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
This fixes a bug where the layers inside a DualPath model were not registered properly, leading DataParallel to fail to move them to the current GPU.

Writing a test case is not possible as it requires multiple GPUs. Tested it locally in my model training code.