### PR TITLE
Bug fix: module snapshot saving throws an error inside Jupyter notebook

### DIFF
--- a/nussl/__init__.py
+++ b/nussl/__init__.py
@@ -5,7 +5,7 @@ except Exception:
     vamp_imported = False
 
 # Current nussl version
-__version__ = '1.1.3rc4'
+__version__ = '1.1.3rc5'
 
 class ImportErrorClass(object):
     def __init__(self, lib, **kwargs):

--- a/nussl/ml/networks/separation_model.py
+++ b/nussl/ml/networks/separation_model.py
@@ -69,7 +69,14 @@ class SeparationModel(nn.Module):
             if 'class' in module:
                 if module['class'] in dir(modules): 
                     class_func = getattr(modules, module['class'])
-                    module_snapshot = inspect.getsource(class_func)
+                    try:
+                        module_snapshot = inspect.getsource(class_func)
+                    except TypeError: # pragma: no cover
+                        module_snapshot = (
+                            "No module snapshot could be found. Did you define "
+                            "your class in an interactive Python environment? "
+                            "See https://bugs.python.org/issue12920 for more details."
+                        )
                 else:
                     class_func = getattr(nn, module['class'])
                     module_snapshot = f'pytorch v{torch.__version__} builtin'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('extra_requirements.txt') as f:
 
 setup(
     name='nussl',
-    version='1.1.3rc4',
+    version='1.1.3rc5',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
If you define your modules in a Jupyter notebook, the snapshot errors out due to
this: https://bugs.python.org/issue12920. This PR fixes this by placing the
module snapshot code inside a try/catch, and puts a default string if the module snapshot could not be captured.