### PR TITLE
SeparationModel improvements - load/save/flexible forward pass.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ v1.1.5
 ------
 - Added load function to SeparationModel.
 - Allow keyword arguments to pass transparently through a SeparationModel.
+- Added runtime arguments to DeepMixin, and a callback that can be implemented by a user
+  to modify an input data dictionary before it's passed to a SeparationModel.
 
 v1.1.4
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,14 @@
 Changelog
 =========
+v1.1.5
+------
+- Added load function to SeparationModel.
+- Allow keyword arguments to pass transparently through a SeparationModel.
+
+v1.1.4
+------
+- Fixed visualization of mel spectrogram.
+
 v1.1.3
 ------
 - Fixed some bugs that happen because of a PyTorch Ignite update.

--- a/nussl/__init__.py
+++ b/nussl/__init__.py
@@ -5,7 +5,7 @@ except Exception:
     vamp_imported = False
 
 # Current nussl version
-__version__ = '1.1.4'
+__version__ = '1.1.5'
 
 class ImportErrorClass(object):
     def __init__(self, lib, **kwargs):

--- a/nussl/ml/networks/separation_model.py
+++ b/nussl/ml/networks/separation_model.py
@@ -274,8 +274,10 @@ class SeparationModel(nn.Module):
             }
             metadata.update(dataset_metadata)
 
-        if val_data is not None:
+        try:
             metadata['val_dataset'] = _prep_metadata(val_data.metadata)
+        except:
+            pass
         
         if trainer is not None:
             train_metadata = {

--- a/nussl/ml/networks/separation_model.py
+++ b/nussl/ml/networks/separation_model.py
@@ -11,6 +11,8 @@ from ... import __version__
 import copy
 
 def _remove_cache_from_tfms(transforms):
+    """Helper function to remove cache from transforms.
+    """
     from ... import datasets
     transforms = copy.deepcopy(transforms)
 
@@ -23,6 +25,8 @@ def _remove_cache_from_tfms(transforms):
 
 
 def _prep_metadata(metadata):
+    """Helper function for preparing metadata before saving a model.
+    """
     metadata = copy.deepcopy(metadata)
     if 'transforms' in metadata:
         metadata['transforms'] = _remove_cache_from_tfms(metadata['transforms'])

--- a/nussl/ml/train/trainer.py
+++ b/nussl/ml/train/trainer.py
@@ -13,9 +13,6 @@ import torch
 from torch import nn
 import numpy as np
 
-from nussl import datasets
-
-
 class ValidationEvents(EventEnum):
     """
     Events based on validation running

--- a/nussl/ml/train/trainer.py
+++ b/nussl/ml/train/trainer.py
@@ -143,24 +143,6 @@ def create_train_and_validation_engines(train_func, val_func=None, device='cpu')
 
     return trainer, validator
 
-
-def _remove_cache_from_tfms(transforms):
-    transforms = copy.deepcopy(transforms)
-
-    if isinstance(transforms, datasets.transforms.Compose):
-        for t in transforms.transforms:
-            if isinstance(t, datasets.transforms.Cache):
-                transforms.transforms.remove(t)
-
-    return transforms
-
-
-def _prep_metadata(metadata):
-    metadata = copy.deepcopy(metadata)
-    metadata['transforms'] = _remove_cache_from_tfms(metadata['transforms'])
-    return metadata
-
-
 def add_validate_and_checkpoint(output_folder, model, optimizer, train_data, trainer,
                                 val_data=None, validator=None, save_by_epoch=None):
     """

--- a/nussl/separation/base/clustering_separation_base.py
+++ b/nussl/separation/base/clustering_separation_base.py
@@ -173,7 +173,7 @@ class ClusteringSeparationBase(MaskSeparationBase):
         responsibilities = responsibilities.reshape(shape[:-1] + (-1,))
         return responsibilities
 
-    def run(self, features=None):
+    def run(self, features=None, **kwargs):
         """
         Clusters the features using the chosen clustering algorithm.
         
@@ -190,7 +190,7 @@ class ClusteringSeparationBase(MaskSeparationBase):
             list: List of Mask objects in self.result_masks.
         """
         if features is None:
-            features = self.extract_features()
+            features = self.extract_features(**kwargs)
 
         if features.shape[:-1] != self.stft.shape:
             raise SeparationException(

--- a/nussl/separation/base/deep_mixin.py
+++ b/nussl/separation/base/deep_mixin.py
@@ -81,7 +81,8 @@ class DeepMixin:
         kwargs : keyword arguments, optional
             Data dictionary after this function is called, by default None
         """
-        return data.update(kwargs)
+        data.update(kwargs)
+        return data
 
     def _get_input_data_for_model(self, **kwargs):
         """

--- a/nussl/separation/base/deep_mixin.py
+++ b/nussl/separation/base/deep_mixin.py
@@ -104,7 +104,6 @@ class DeepMixin:
 
         data = {'mix': self.audio_signal}
         data = self.transform(data)
-        data = self.modify_input_data(data, **kwargs)
 
         for key in data:
             if torch.is_tensor(data[key]):
@@ -112,6 +111,8 @@ class DeepMixin:
                 if self.metadata['num_channels'] == 1:
                     # then each channel is processed indep
                     data[key] = data[key].transpose(0, self.channel_dim)
+        
+        data = self.modify_input_data(data, **kwargs)       
         self.input_data = data
         return self.input_data
 

--- a/nussl/separation/base/deep_mixin.py
+++ b/nussl/separation/base/deep_mixin.py
@@ -4,7 +4,6 @@ import json
 
 from ...ml import SeparationModel
 from ...datasets import transforms as tfm
-from ...core.migration import SafeModelLoader
 
 OMITTED_TRANSFORMS = (
     tfm.GetExcerpt,
@@ -31,16 +30,11 @@ class DeepMixin:
             metadata (dict): metadata associated with model, used for making
             the input data into the model.
         """
-        safe_loader = SafeModelLoader()
-        model_dict = safe_loader.load(model_path, 'cpu')
-        metadata = model_dict['metadata']
-
-        model = SeparationModel(metadata['config'])
-        model.load_state_dict(model_dict['state_dict'])
+        
         device = device if torch.cuda.is_available() else 'cpu'
 
         self.device = device
-
+        model, metadata = SeparationModel.load(model_path)
         model = model.to(device).eval()
         self.model = model
         self.config = metadata['config']

--- a/nussl/separation/deep/deep_audio_estimation.py
+++ b/nussl/separation/deep/deep_audio_estimation.py
@@ -15,23 +15,20 @@ class DeepAudioEstimation(DeepMixin, SeparationBase):
         model_path (str, optional): Path to the model that will be used. Can be None, 
           so that you can initialize a class and load the model later.  
           Defaults to None.
-        extra_data: A dictionary containing any additional data that will 
-          be merged with the output dictionary.
         device (str, optional): Device to put the model on. Defaults to 'cpu'.
         **kwargs (dict): Keyword arguments for MaskSeparationBase.
     """
-    def __init__(self, input_audio_signal, model_path=None, device='cpu', 
-                 extra_data=None, **kwargs):
+    def __init__(self, input_audio_signal, model_path=None, device='cpu',  
+                 **kwargs):
         super().__init__(input_audio_signal, **kwargs)
         if model_path is not None:
             self.load_model(model_path, device=device)
         self.model_output = None
-        self.extra_data = extra_data
         # audio channel dimension in an audio model
         self.channel_dim = 1
 
-    def forward(self):
-        input_data = self._get_input_data_for_model(self.extra_data)
+    def forward(self, **kwargs):
+        input_data = self._get_input_data_for_model(**kwargs)
         with torch.no_grad():
             output = self.model(input_data)
             if 'audio' not in output:

--- a/nussl/separation/deep/deep_clustering.py
+++ b/nussl/separation/deep/deep_clustering.py
@@ -20,8 +20,6 @@ class DeepClustering(DeepMixin, ClusteringSeparationBase):
           so that you can initialize a class and load the model later.  
           Defaults to None.
         device (str, optional): Device to put the model on. Defaults to 'cpu'.
-        extra_data (dict, optional): Any extra data that is to be passed at runtime
-          to the SeparationModel.
         **kwargs (dict): Keyword arguments for ClusteringSeparationBase and the 
           clustering object used for clustering (one of KMeans, GaussianMixture,
           MiniBatchKmeans).
@@ -30,19 +28,18 @@ class DeepClustering(DeepMixin, ClusteringSeparationBase):
         SeparationException: If 'embedding' isn't in the output of the model.
     """
     def __init__(self, input_audio_signal, num_sources, model_path=None,
-                 device='cpu', extra_data=None, **kwargs):
+                 device='cpu', **kwargs):
         super().__init__(input_audio_signal, num_sources, **kwargs)
         if model_path is not None:
             self.load_model(model_path, device=device)
         # audio channel dimension in a dpcl model
         self.channel_dim = -1
-        self.extra_data = extra_data
 
     def forward(self):
         return self.extract_features()
 
-    def extract_features(self):
-        input_data = self._get_input_data_for_model(self.extra_data)
+    def extract_features(self, **kwargs):
+        input_data = self._get_input_data_for_model(**kwargs)
         with torch.no_grad():
             output = self.model(input_data)
             if 'embedding' not in output:

--- a/nussl/separation/deep/deep_mask_estimation.py
+++ b/nussl/separation/deep/deep_mask_estimation.py
@@ -17,24 +17,20 @@ class DeepMaskEstimation(DeepMixin, MaskSeparationBase):
         model_path (str, optional): Path to the model that will be used. Can be None, 
           so that you can initialize a class and load the model later.  
           Defaults to None.
-        extra_data: A dictionary containing any additional data that will 
-          be merged with the output dictionary. This can come from a dataset,
-          or contain a query, etc.
         device (str, optional): Device to put the model on. Defaults to 'cpu'.
         **kwargs (dict): Keyword arguments for MaskSeparationBase.
     """
     def __init__(self, input_audio_signal, model_path=None, device='cpu', 
-                 extra_data=None, **kwargs):
+                 **kwargs):
         super().__init__(input_audio_signal, **kwargs)
         if model_path is not None:
             self.load_model(model_path, device=device)
         self.model_output = None
-        self.extra_data = extra_data
         # audio channel dimension in a mask estimation model
         self.channel_dim = -1
 
-    def forward(self):
-        input_data = self._get_input_data_for_model(self.extra_data)
+    def forward(self, **kwargs):
+        input_data = self._get_input_data_for_model(**kwargs)
         with torch.no_grad():
             output = self.model(input_data)
             if 'mask' not in output:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('extra_requirements.txt') as f:
 
 setup(
     name='nussl',
-    version='1.1.4',
+    version='1.1.5',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',

--- a/tests/ml/test_gaussian_mixture.py
+++ b/tests/ml/test_gaussian_mixture.py
@@ -40,7 +40,7 @@ def test_ml_gaussian_mixture():
 
         for nb in range(predictions.shape[0]):
             ami = adjusted_mutual_info_score(labels[nb], predictions[nb])
-            assert ami == 1.0
+            assert np.allclose(ami, 1.0)
 
         # with random init, we compare ami with sklearn impl.
         # covariance_type = 'full' has some issues, i think due to init.

--- a/tests/separation/test_deep.py
+++ b/tests/separation/test_deep.py
@@ -111,7 +111,7 @@ def test_deep_mixin(overfit_model):
     assert deep_mixin.audio_signal.sample_rate == deep_mixin.metadata['sample_rate']
 
     dummy_data = {'one_hot': np.random.rand(100)}
-    input_data = deep_mixin._get_input_data_for_model(dummy_data)
+    input_data = deep_mixin._get_input_data_for_model(**dummy_data)
 
     assert 'one_hot' in input_data
 


### PR DESCRIPTION
This PR improves SeparationModel a bit. Save and load functionality are now in SeparationModel. Keyword arguments can now be passed into a separation model like so:

```
separation_model(mix_audio=..., other_stuff=...)
```

Instead of needing to do

```
data = dict(mix_audio=..., other_stuff=...)
separation_model(data)
```

This change is backwards compatible, so the old way still works too.