### PR TITLE
Fixing mel spectrogram.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ v1.1.5
 - Added runtime arguments to DeepMixin, and a callback that can be implemented by a user
   to modify an input data dictionary before it's passed to a SeparationModel.
 - Added an OverlapAdd algorithm that can be used with any separation object.
+- Adding argument to MelProjection so that it matches librosa mel filters.
 
 v1.1.4
 ------

--- a/nussl/ml/networks/modules/blocks.py
+++ b/nussl/ml/networks/modules/blocks.py
@@ -248,9 +248,10 @@ class MelProjection(nn.Module):
         clamp: (bool) Whether to clamp the output values of the transform between 0.0 and 1.0. Used for transforming
             a mask in and out of the mel-domain. Defaults to False.
         trainable: (bool) Whether the mel transform can be adjusted by the optimizer. Defaults to False.
+        normalize (bool): Whether or not to divide the mel filters by the sum of each column. Defaults to True.
     """
     def __init__(self, sample_rate, num_frequencies, num_mels, direction='forward',
-                 clamp=False, trainable=False):
+                 clamp=False, trainable=False, normalize=True):
         super(MelProjection, self).__init__()
         self.num_mels = num_mels
         if direction not in ['backward', 'forward']:
@@ -267,7 +268,8 @@ class MelProjection(nn.Module):
             self.add_module('transform', nn.Linear(*shape))
 
             mel_filters = librosa.filters.mel(sample_rate, 2 * (num_frequencies - 1), num_mels)
-            mel_filters = (mel_filters.T / (mel_filters.sum(axis=1) + 1e-8)).T
+            if normalize:
+                mel_filters = (mel_filters.T / (mel_filters.sum(axis=1) + 1e-8)).T
             filter_bank = (
                 mel_filters
                 if self.direction == 'forward'


### PR DESCRIPTION
Adds a `normalize` arg to MelProjection so that the filters from librosa can be used without dividing by the row. The division was so that invertible mel would work, but we won't always want invertible mel, and would want to match `librosa.feature.melspectrogram`.