### PR TITLE
Unpinning zarr + adding release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - "master"
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Retrieve version
+        run: |
+          echo "::set-output name=TAG_NAME::$(grep -i -o -P '(?<=version=\")[^\"]+(?=\")' setup.py)"
+        id: version
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: v${{ steps.version.outputs.TAG_NAME }}
+          release_name: v${{ steps.version.outputs.TAG_NAME }}
+          body: Nothing
+          draft: false
+          prerelease: false

--- a/nussl/__init__.py
+++ b/nussl/__init__.py
@@ -5,7 +5,7 @@ except Exception:
     vamp_imported = False
 
 # Current nussl version
-__version__ = '1.1.6'
+__version__ = '1.1.7'
 
 class ImportErrorClass(object):
     def __init__(self, lib, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ matplotlib
 museval
 musdb
 pyyaml
-zarr==2.3.0
-numcodecs==0.6.2
+zarr
 ffmpy
 torch
 pytorch-ignite

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('extra_requirements.txt') as f:
 
 setup(
     name='nussl',
-    version='1.1.6',
+    version="1.1.7",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
Zarr has been pinned for 2.3.0 for some time. Let's try unpinning it and seeing if tests pass.