### PR TITLE
torch.rfft -> torch.fft.rfft

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 v1.1.8
 ------
-
+- Updated torch.fft -> torch.fft.rfft so it works with PyTorch 1.8.
 
 v1.1.7
 ------

--- a/nussl/ml/networks/modules/filter_bank.py
+++ b/nussl/ml/networks/modules/filter_bank.py
@@ -297,8 +297,8 @@ class STFT(FilterBank):
         )
         cutoff = 1 + self.filter_length // 2
         fourier_basis = torch.cat([
-            fourier_basis[:, :cutoff, 0],
-            fourier_basis[:, :cutoff, 1]
+            torch.real(fourier_basis[:, :cutoff]),
+            torch.imag(fourier_basis[:, :cutoff])
         ], dim=1)
         return fourier_basis.float()
     

--- a/nussl/ml/networks/modules/filter_bank.py
+++ b/nussl/ml/networks/modules/filter_bank.py
@@ -293,8 +293,7 @@ class STFT(FilterBank):
     
     def _get_fft_basis(self):
         fourier_basis = torch.fft.rfft(
-            torch.eye(self.filter_length), 
-            1, onesided=True
+            torch.eye(self.filter_length)
         )
         cutoff = 1 + self.filter_length // 2
         fourier_basis = torch.cat([

--- a/nussl/ml/networks/modules/filter_bank.py
+++ b/nussl/ml/networks/modules/filter_bank.py
@@ -292,7 +292,7 @@ class STFT(FilterBank):
         return data
     
     def _get_fft_basis(self):
-        fourier_basis = torch.rfft(
+        fourier_basis = torch.fft.rfft(
             torch.eye(self.filter_length), 
             1, onesided=True
         )


### PR DESCRIPTION
PyTorch changed their FFT API to match numpy in PyTorch 1.8. This PR updates the one call we make to it.